### PR TITLE
Minor updates to facilitate build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,7 @@
 # Specific directories to ignore
 **/DirectusExtensions
 **/Swarm
-**/data
+# **/data
 
 # include sequelize bridge
 !Server/

--- a/02_Util/src/util/directus.ts
+++ b/02_Util/src/util/directus.ts
@@ -136,7 +136,7 @@ export class DirectusUtil implements ConfigStore {
     if (filePath) {
       formData.append('folder', filePath);
     }
-    formData.append('file', new Blob([content]), fileName);
+    formData.append('file', new Blob([new Uint8Array(content)]), fileName);
     try {
       const file = await this._client.request(uploadFiles(formData));
       return file['id'];

--- a/Server/deploy.Dockerfile
+++ b/Server/deploy.Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /usr/local/apps/citrineos
 COPY . .
 RUN npm run install-all && npm run build
 
+RUN echo "Copying data and hasura metadata folders..."
+COPY /Server/data /usr/local/apps/citrineos/Server
+COPY Server/hasura-metadata /usr/local/apps/citrineos/Server
+
 # The final stage, which copies built files and prepares the run environment
 # Using a slim image to reduce the final image size
 FROM node:22-slim


### PR DESCRIPTION
- Patched file that was failing during GitHub build - same action on Citrine's own repo was not failing, this needs to be addressed
- Add actions to build to copy `data` and `hasura-metadata` into the image, this replaces a runtime-patch that we were using in the demo
- Remove `data` from `dockerignore` to be able to copy it in